### PR TITLE
Release v6.6.1

### DIFF
--- a/SampleApp/mobile/src/main/res/layout/activity_player.xml
+++ b/SampleApp/mobile/src/main/res/layout/activity_player.xml
@@ -82,6 +82,7 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/general_padding"
         android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
         android:layout_above="@id/btnSwitchStreams"
         android:mediaRouteTypes="user"
         android:visibility="visible" />

--- a/SampleApp/mobile/src/main/res/values/themes.xml
+++ b/SampleApp/mobile/src/main/res/values/themes.xml
@@ -12,6 +12,7 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="mediaRouteTheme">@style/CustomMediaRouterTheme</item>
     </style>
 
     <style name="Theme.NPOPlayer" parent="Theme.MaterialComponents.DayNight.NoActionBar">
@@ -28,10 +29,18 @@
         <item name="android:windowTranslucentStatus">true</item>
 
         <!-- Customize your theme here. -->
+        <item name="mediaRouteTheme">@style/CustomMediaRouterTheme</item>
     </style>
 
 
     <!-- Following styles can be used to style the cast widgets -->
+    <style name="CustomMediaRouterTheme" parent="Theme.MediaRouter.Light">
+        <item name="mediaRouteButtonStyle">@style/CustomMediaRouteButtonStyle</item>
+    </style>
+    <style name="CustomMediaRouteButtonStyle" parent="Widget.MediaRouter.MediaRouteButton">
+        <item name="mediaRouteButtonTint">#ffffff</item>
+    </style>
+
     <style name="CustomCastExpandedController" parent="CastExpandedController" />
 
     <style name="CustomCastIntroOverlay" parent="CastIntroOverlay">

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 #Library
-libVersionName=6.6.0-SNAPSHOT
+libVersionName=6.6.1-SNAPSHOT
 # Sample app
 appName=NPO Player Android SampleApp
 appNameShort=SampleApp

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 #Library
-libVersionName=6.6.1-SNAPSHOT
+libVersionName=6.6.1
 # Sample app
 appName=NPO Player Android SampleApp
 appNameShort=SampleApp


### PR DESCRIPTION
### 6.6.1

- [PLAYER-3477](https://publiekeomroep.atlassian.net/browse/PLAYER-3477) Fixed issue where onStart/onResume behaviour for Exoplayer is more aggressive than for Bitmovin
- [PLAYER-3473](https://publiekeomroep.atlassian.net/browse/PLAYER-3473) Fix livestream offset after Ad playback

[PLAYER-3477]: https://publiekeomroep.atlassian.net/browse/PLAYER-3477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAYER-3473]: https://publiekeomroep.atlassian.net/browse/PLAYER-3473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ